### PR TITLE
Add-Proofline

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ A reader-first map of where AI agent reliability is won and lost. Reliability is
 
 **[TypeScript, Python] AgentLens** ([agentkitai/agentlens](https://github.com/agentkitai/agentlens)): MCP-native observability and audit-trail platform that records LLM calls, tool invocations, and decisions in an append-only, SHA-256 hash-chained, verifiable event log.
 
-**[Python] Proofline** ([ceodaradigu/proofline-agent](https://github.com/ceodaradigu/proofline-agent)): verification-first agent that turns task contracts into deterministic SHA-256 proof packets, rejects missing, stale, or contradictory evidence, and gates external actions behind human approval.
+**[Python] Proofline** ([ceodaradigu/proofline-agent](https://github.com/ceodaradigu/proofline-agent)): verification-first agent that turns task contracts into deterministic SHA-256 proof packets, rejects missing, stale, or contradictory evidence, and gates external actions behind human approval. MIT-licensed, 2026-present.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ A reader-first map of where AI agent reliability is won and lost. Reliability is
 
 **[TypeScript, Python] AgentLens** ([agentkitai/agentlens](https://github.com/agentkitai/agentlens)): MCP-native observability and audit-trail platform that records LLM calls, tool invocations, and decisions in an append-only, SHA-256 hash-chained, verifiable event log.
 
+**[Python] Proofline** ([ceodaradigu/proofline-agent](https://github.com/ceodaradigu/proofline-agent)): verification-first agent that turns task contracts into deterministic SHA-256 proof packets, rejects missing, stale, or contradictory evidence, and gates external actions behind human approval.
+
 ---
 
 ## Security Auditing and Scanners


### PR DESCRIPTION
## What changed

Adds Proofline to the Decision-Record Tools section.

## Why

Proofline is a public Python agent focused on deterministic proof packets, evidence validation, and human approval gates for external actions. This matches the list's decision-record and accountability scope.

## Checks

- Confirmed the repository link is public and working.
- Confirmed Proofline is not already listed or proposed.
- Ran `git diff --check` successfully.

AI assistance was used to draft and verify this single-entry contribution.
