### PR TITLE
Standards: add the tamper-evident log and attestation primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,16 @@ Standards and governance instruments for agent reliability and accountability. P
 
 **[Standard] C2PA Technical Specification / Content Credentials** ([spec.c2pa.org](https://spec.c2pa.org/specifications/specifications/2.2/specs/_attachments/C2PA_Specification.pdf), [c2pa-rs](https://github.com/contentauth/c2pa-rs)): cryptographically signed, tamper-evident metadata standard that records the origin and edit history of media, including a manifest for AI-generated and AI-edited content. C2PA (Adobe, Microsoft, BBC, Intel, Truepic, Sony, and others), v2.2 (2025).
 
+**[Standard] Certificate Transparency (RFC 6962, RFC 9162)** ([RFC 6962](https://www.rfc-editor.org/rfc/rfc6962), [RFC 9162](https://www.rfc-editor.org/rfc/rfc9162)): append-only Merkle tree log with inclusion proofs, showing an entry is in the log, and consistency proofs, showing the log was only appended to; the origin of the verifiable-log pattern that tamper-evident agent trails reuse. IETF, 2013 (v1) / 2021 (v2).
+
+**[Standard] in-toto Attestation Framework** ([in-toto/attestation](https://github.com/in-toto/attestation), [in-toto.io](https://in-toto.io/)): signed, machine-readable statements binding a subject artifact to a predicate describing what was done to it, giving a common envelope for provenance claims across steps and tools. in-toto / CNCF, 2018-2026 (living spec).
+
+**[Standard] SLSA (Supply-chain Levels for Software Artifacts)** ([slsa.dev](https://slsa.dev/spec/v1.0/)): graded framework defining what provenance a build must produce and how tamper-resistant it must be, with each level naming concrete requirements rather than intent. OpenSSF, v1.0 (2023).
+
+**[Standard] DSSE (Dead Simple Signing Envelope)** ([secure-systems-lab/dsse](https://github.com/secure-systems-lab/dsse)): signing envelope that authenticates a payload together with its type, removing the canonicalization ambiguity that lets a signature be replayed against a different interpretation of the same bytes; used by in-toto and Sigstore. Secure Systems Lab, 2021-2026.
+
+**[Tool] Rekor** ([sigstore/rekor](https://github.com/sigstore/rekor)): transparency log service for signed software artifacts and attestations, built on an append-only Merkle log and serving inclusion and consistency proofs over a public API. Sigstore / OpenSSF, Apache-2.0.
+
 ---
 
 ## Related Projects


### PR DESCRIPTION
Five entries in **Standards and Frameworks**.

The list covers the AI specific governance instruments well (EU AI Act Art. 12, NIST, ISO 42001, OWASP, C2PA), but not the log and attestation standards that tamper-evident agent trails are actually built on. Several existing entries describe append-only, hash-chained, verifiable logs with no primary source in the list to point at.

| Entry | Why it belongs |
|---|---|
| Certificate Transparency (RFC 6962, RFC 9162) | The origin of the verifiable-log pattern: inclusion proofs and, importantly, consistency proofs, which is what distinguishes an append-only log from one that can be rewritten |
| in-toto Attestation Framework | The common envelope for provenance claims, subject bound to predicate |
| SLSA v1.0 | Grades what provenance a build must produce, and how tamper-resistant |
| DSSE | Authenticates payload together with its type, which is what stops a signature being replayed against a different reading of the same bytes |
| Rekor | A running transparency log serving inclusion and consistency proofs over a public API |

Rekor is tagged `[Tool]` rather than `[Standard]` since it is an implementation.

All links checked (HTTP 200 / repos resolve). Primary sources only: RFC Editor for the RFCs, the specification sites and canonical repos for the rest. No self-promotion; none of these are mine.

Happy to split this into one PR per entry, or drop any that read as out of scope for the list.