### PR TITLE
Add Agent Oversight Framework (AI 执行与监察体系) to Standards and Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,6 +522,8 @@ several tools in this list build on.
 
 **\[Standard\] DSSE (Dead Simple Signing Envelope)** ([secure-systems-lab/dsse](https://github.com/secure-systems-lab/dsse)): signing envelope that authenticates a payload together with its type, removing the canonicalization ambiguity that lets a signature be replayed against a different interpretation of the same bytes; used by in-toto and Sigstore. Secure Systems Lab, 2021-2026.
 
+**[Standard] Agent Oversight Framework（AI 执行与监察体系）** ([spec repo](https://github.com/ZhangRui987/agent-oversight-framework)): A layered governance specification that grades every claim A/B/C/D against 26 citable sources and defines an evidence-integrity subsystem (E1–E5) for reconstructing what an agent did, what it relied on, and why it acted. ZhangRui987 (independent), v1.0.0 (2026-08-30).
+
 **\[Tool\] Rekor** ([sigstore/rekor](https://github.com/sigstore/rekor)): transparency log service for signed software artifacts and attestations, built on an append-only Merkle log and serving inclusion and consistency proofs over a public API. Sigstore / OpenSSF, Apache-2.0, 2020-present.
 
 ---


### PR DESCRIPTION
Adds a governance specification to **Standards and Governance → Standards and Frameworks**.

**Entry format** follows the `[Standard]` convention used by MCP, A2A and NIST AI RMF in this section.

**Why it fits**: this list's stated goal is *"being able to establish what an agent did, what it relied on, why it acted, and whether the action was right."* That is precisely what the spec is built around:

- **Evidence-integrity subsystem E1–E5** — kernel-level collection, TOCTOU re-reads, append-only externalization, multi-source cross-validation, collector-point integrity. Designed against the failure mode where the sandbox logs themselves are forged (~7% of transcripts in the 2026-07 OpenAI/Hugging Face incident; sourced to the OpenAI technical report and the METR/Redwood independent investigation, both linked in `REFERENCES.md`)
- **Mechanism traceability table** — every mechanism mapped to a graded, citable source
- **A/B/C/D evidence grading with a public correction loop** — the `evidence-correction` issue template lets anyone submit an upgrade or downgrade; grades are a reviewable state, not a hidden defect
- **Back-propagation checklist** — the spec's own revision process is an auditable artifact (adjacent paragraphs, related tables, changelog vs. open-problem list)

**Self-check before submitting**:
- Hostname resolves: `github.com` ✓
- License stated: CC BY-SA 4.0 (docs) / Apache-2.0 (code) ✓
- No arXiv title check applies — this is a spec repository, not a paper ✓
- Happy to run `tools/check_links.py` locally and adjust if CI flags anything

**One note for the maintainer**: this is a Chinese-language-first specification (English translation is tracked in `i18n/TRANSLATION.md`, issue #1). If the list prefers English-only entries, I can submit `README.en.md` first and re-open this then — happy to follow your convention either way.