### PR TITLE
Tools: add sofagent

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ Every component above is also listed in the topical section it belongs to, under
 
 **\[TypeScript\] aegis** ([Justin0504/Aegis](https://github.com/Justin0504/Aegis)): runtime policy enforcement for AI agents with a cryptographic audit trail, human-in-the-loop approvals, and a kill switch, implemented as a wrapper around agent code. MIT-licensed, 2026-present.
 
+**\[TypeScript\] sofagent** ([KongFangXun/sofagent](https://github.com/KongFangXun/sofagent)): commit-time audit engine for AI agents that scans git diffs with 24 rules covering secret leaks, out-of-scope edits, blind modifications without prior reads, prompt injection in commit messages, and unauthorized file changes, writing results to an HMAC-signed local audit history, with MCP tools for governance aggregation and a doctor command for integrity checks. MIT-licensed, 2026-present.
+
 **\[Python\] halo-record** ([bkuan001/halo-record](https://github.com/bkuan001/halo-record)): dependency-free recorder that seals tool calls, model calls, and approvals into a SHA-256 hash-chained JSONL log verifiable without trusting the operator, with optional RFC 3161 timestamping and OpenTelemetry GenAI span ingestion. Apache-2.0, 2026-present.
 
 **\[Python, TypeScript\] Agent Governance Toolkit** ([microsoft/agent-governance-toolkit](https://github.com/microsoft/agent-governance-toolkit)): policy enforcement, agent identity, and execution sandboxing with a Merkle-chained audit trail and a Decision BOM, published with control mappings to the OWASP Agentic Top 10, NIST AI RMF 1.0, the EU AI Act, and SOC 2. MIT-licensed, 2026-present; public preview with breaking changes expected.


### PR DESCRIPTION
## Add sofagent to Decision-Record Tools

**Tool title:** sofagent

**Primary link:** https://github.com/KongFangXun/sofagent

**Target section:** Audit Trails and Decision Records → Decision-Record Tools

**One-sentence summary:** Commit-time audit engine for AI agents that scans git diffs with 24 rules (secret leaks, out-of-scope edits, blind modifications, prompt injection in commit messages, unauthorized file changes) and writes results to an HMAC-signed local audit history, with MCP tools for governance aggregation and a doctor command for integrity checks.

**Implementation language:** TypeScript

**License:** MIT

**Activity period:** 2026-present

**Entry added after the aegis entry**, following the section's grouping (governance/approval tools first, recording/provenance tools after).

Local verification run per CONTRIBUTING:
- `python tools/inventory.py README.md` — passes, repository count 90 → 91
- `python tools/check_links.py README.md --out link-audit-local.md --delay 0.10 --timeout 15 --retries 2 --retry-backoff 1 --failure-policy pull-request` — sofagent repo link reachable (HTTP 200)

I am the author and maintainer of sofagent.
