### PR TITLE
Add agent-watch to agent auditing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,8 @@ Tools and platforms for agent observability, evaluation, and reliability. An ins
 
 **\[Python\] AgentCheck** ([WaseemGhanem98/AgentCheck](https://github.com/WaseemGhanem98/AgentCheck)): open-source behavioral testing tool for tool-using AI agents that simulates declared tool execution while evaluating tool calls, failures, retries, confirmations, destructive actions, action sequencing, and fabricated success, with integrations for OpenAI Agents SDK, PydanticAI, and custom Python agents. Apache-2.0, 2026-present.
 
+**\[Shell\] agent-watch** ([soul-sol/agent-watch](https://github.com/soul-sol/agent-watch)): POSIX-shell launcher and one-shot watcher for background coding agents that classifies runs as running, done, failed, or stalled from PID state, recorded exit code, and tail-scoped completion markers, with structured Codex JSONL terminal-event support. MIT-licensed, 2026-present.
+
 ---
 
 ## Standards and Governance


### PR DESCRIPTION
## What this adds

This adds **agent-watch** to **Tools and Platforms** using the list's required tool-entry format. It is an MIT-licensed POSIX-shell launcher and one-shot watcher that distinguishes running, completed, failed, and stalled background coding-agent runs using process state, a recorded exit code, tail-scoped completion markers, and structured Codex JSONL terminal events.

The auditability gap it addresses is a false completion conclusion: a missing process alone cannot distinguish a successful run from a worker that stopped for approval or ended without a conclusion. The watcher preserves and evaluates independent runtime evidence so the operator can diagnose that state explicitly.

Disclosure: I maintain `agent-watch`.

## Checks

- `python3.12 tools/inventory.py README.md`
- `python3.12 tools/check_links.py README.md --out /tmp/awesome-auditable-ai-link-audit.md --delay 0.05 --timeout 15 --retries 2 --retry-backoff 1 --failure-policy pull-request`
- Result: 266 destinations checked, 0 failures, 0 warnings; the added repository resolved with HTTP 200.
- `git diff --check`
